### PR TITLE
changed recorder UI to be translucent, bottom-sticky overlay

### DIFF
--- a/TODO
+++ b/TODO
@@ -6,10 +6,11 @@ FEATURES:
       [ ] replace WEBM encoding w/FLAC encoding (e.g., https://github.com/mmig/speech-to-flac, https://github.com/mmig/libflac.js)
         [x] refactor index.js (see: TECHNICAL HEALTH)
         [x] merge refactor branch into master branch
-        [ ] rebase FLAC branch on top of master branch @est(30 minutes)
+        [ ] rebase FLAC branch on top of ]master branch @est(30 minutes)
         [ ] merge record.js with main.js
   
   PLANNED:
+    [ ] make UI mobile-friendly (currently looks just like desktop app)
     [ ] show user visual indicator that they can't change noises while recording @ux
     [x] show user (a more obvious) visual indicator that a noise has been recorded @ux
     [ ] add wizard (easy sequential navigation) @ux

--- a/server/static/index.css
+++ b/server/static/index.css
@@ -75,12 +75,23 @@ a {
 }
 
 /* Recorder */
+.Tray {
+  position: fixed;
+  position: sticky;
+  bottom: 0;
+  margin-left: 15%;
+  margin-right: 15%;
+}
 
 .Centered {
   display: flex;
   flex-direction: row;
   align-items: center;
   margin: 0 auto;
+  justify-content: center;
+}
+.Centered-column--fill {
+  flex: 1;
 }
 
 .Recorder {
@@ -104,10 +115,6 @@ a {
   flex: 2;
 }
 
-.Recorder-examples {
-  flex: 1;
-}
-
 .Recorder-title {
   font-size: 24px;
   margin-bottom: 10px;
@@ -116,9 +123,11 @@ a {
 .Recorder-examples {
   border-radius: 5px;
   padding: 10px;
-  background-color: #f6f6f6;
-  font-style: 16px;
+  background-color: rgba(216,216,216,0.5);
+  font-size: 18px;
   margin-bottom: 10px;
+  margin-left: 10px;
+  float: right;
 }
 
 .Recorder-exampleAudio {
@@ -196,21 +205,22 @@ a {
 
 
 .Arrow {
-  color: #d6d6d6;
+  color: rgba(183,183,183,0.5);
   width: 0;
   height: 0;
   border-top: 60px solid transparent;
   border-bottom: 60px solid transparent;
   font-size: 0px;
   cursor: pointer;
+  background-color: transparent;
 }
 
 .Arrow--disabled {
-  color: #efefef;
+  color: rgba(207,207,207,0.5);
   cursor: auto;
 }
 .Arrow:not(.Arrow--disabled):hover {
-  color: #d0d0d0;
+  color: rgba(159,159,159,0.5);
 }
 
 .Arrow--left {

--- a/server/templates/index.html
+++ b/server/templates/index.html
@@ -1,56 +1,71 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <title>Noise Sample Collection</title>
-    <meta name="description" content="" />
-    <link rel="stylesheet" type="text/css" href="static/index.css" />
-  </head>
-  <body>
-    <!-- TODO: get rid of the below form after we're done; only used as reference, but may also be used as a backup for browsers that don't support getUserMedia() -->
-    <form style="display: none" enctype="multipart/form-data" action="/upload" method="POST">
-      <input name="noise" type="file" accept="audio/*;capture=microphone">
-      <br>
-      <input type="submit">
-    </form>
-    <div class="RecordingList" data-id="list">
-      <ul class="RecordingList-container" data-id="list-container"></ul>
-    </div>
-    <div class="Centered">
-      <button class="Arrow Arrow--left" data-id="goBack">Go to previous noise</button>
-      <div class="Recorder" data-id="recorder">
-        <p class="Recorder-title" data-id="title"></p>
-        <hr>
-        <div class="Recorder-info">
-          <div class="Recorder-metadata">
-            <p class="Recorder-description" data-id="description"></p>
-            <!-- TODO: use this if we are going to have a long description as well -->
-            <p class="Recorder-instructions" style="display: none"></p>
-          </div>
+
+<head>
+  <title>Noise Sample Collection</title>
+  <meta name="description" content="" />
+  <link rel="stylesheet" type="text/css" href="static/index.css" />
+</head>
+
+<body>
+  <!-- TODO: get rid of the below form after we're done; only used as reference, but may also be used as a backup for browsers that don't support getUserMedia() -->
+  <form style="display: none" enctype="multipart/form-data" action="/upload" method="POST">
+    <input name="noise" type="file" accept="audio/*;capture=microphone">
+    <br>
+    <input type="submit">
+  </form>
+  <div class="RecordingList" data-id="list">
+    <ul class="RecordingList-container" data-id="list-container"></ul>
+  </div>
+  <div class="Tray">
+    <div class="Recorder" data-id="recorder">
+      <p class="Recorder-title" data-id="title"></p>
+      <hr>
+      <div class="Recorder-info">
+        <div class="Recorder-metadata">
           <div class="Recorder-examples">
             <p class="Recorder-exampleAudio">
-              Listen to an example:<br>
+              Listen to an example:
+              <br>
+              <br>
               <!-- TODO: convert to accessible custom controls -->
               <audio class="Recorder-preview" data-id="preview" style="display: none" controls="">
               </audio>
             </p>
             <!-- TODO: only show this if there are actually video examples -->
             <p class="Recorder-exampleVideo" style="display: none">
-              Watch a video of the mouth movement:<br><a href="#">Video of mouth movement</a>
+              Watch a video of the mouth movement:
+              <br>
+              <a href="#">Video of mouth movement</a>
             </p>
           </div>
-        </div>
-        <div class="Recorder-actions">
-          <!-- TODO: hide the below until we allow the user to listen/download to their own recording -->
-          <audio style="display: none" data-id="player" class="Player" controls disabled></audio>
-          <a style="display: none" data-id="download" class="DownloadLink DownloadLink--disabled">Download</a>
-          <button data-id="recordButton" class="Recorder-recordButton">Record</button>
-          <p data-id="recorderTime" class="Recorder-time">00:00</p>
-          <p data-id="recorderStatus" class="Recorder-status">Waiting to record</p>
+          <p class="Recorder-description" data-id="description"></p>
+          <!-- TODO: use this if we are going to have a long description as well -->
+          <p class="Recorder-instructions" style="display: none"></p>
         </div>
       </div>
-      <button class="Arrow Arrow--right" data-id="goForward">Go to next noise</button>
+      <div class="Centered">
+        <div class="Centered-column">
+          <button class="Arrow Arrow--left" data-id="goBack">Go to previous noise</button>
+        </div>
+        <div class="Centered-column--fill">
+          <div class="Recorder-actions">
+            <!-- TODO: hide the below until we allow the user to listen/download to their own recording -->
+            <audio style="display: none" data-id="player" class="Player" controls disabled></audio>
+            <a style="display: none" data-id="download" class="DownloadLink DownloadLink--disabled">Download</a>
+            <button data-id="recordButton" class="Recorder-recordButton">Record</button>
+            <p data-id="recorderTime" class="Recorder-time">00:00</p>
+            <p data-id="recorderStatus" class="Recorder-status">Waiting to record</p>
+          </div>
+        </div>
+        <div class="Centered-column">
+          <button class="Arrow Arrow--right" data-id="goForward">Go to next noise</button>
+        </div>
+      </div>
     </div>
   </div>
+  </div>
   <script type="module" src="static/index.js"></script>
-  </body>
+</body>
+
 </html>


### PR DESCRIPTION
With several list items, recorder UI was being pushed down the page. This PR modifies the recorder UI to be a translucent overlay that sticks to the bottom of the page (or is just fixed if position:sticky is not supported). It's considered a quickfix as it may not be the ideal user experience, but hopefully it works well enough to ship as MVP.