### PR TITLE
Feature/separate record from stop

### DIFF
--- a/server/static/components/recorder.js
+++ b/server/static/components/recorder.js
@@ -148,22 +148,31 @@ function renderButton({
   // TODO: look into other ways of doing this, including using the original reference to the handler
   const recordButton = document.querySelector('[data-id=recordButton]');
   const recordButtonClone = recordButton.cloneNode(true);
+  const stopButton = document.querySelector('[data-id=stopButton]');
+  const stopButtonClone = stopButton.cloneNode(true);
 
   if (disabled) {
     recordButtonClone.classList.add('Recorder-recordButton--disabled');
+    stopButtonClone.classList.add('Recorder-stopButton--disabled');
   } else {
     recordButtonClone.classList.remove('Recorder-recordButton--disabled');
+    stopButtonClone.classList.remove('Recorder-stopButton--disabled');
   }
-  recordButtonClone.addEventListener('click', onButtonClick);
-  //recordButtonClone.disabled = disabled;
+  recordButtonClone.disabled = disabled;
+  stopButtonClone.disabled = disabled;
 
   if (recording) {
     recordButtonClone.classList.add('Recorder-recordButton--recording');
+    stopButtonClone.classList.remove('Recorder-stopButton--stopped');
+    stopButtonClone.addEventListener('click', onButtonClick);
   } else {
     recordButtonClone.classList.remove('Recorder-recordButton--recording');
+    stopButtonClone.classList.add('Recorder-stopButton--stopped');
+    recordButtonClone.addEventListener('click', onButtonClick);
   }
 
   recordButton.parentNode.replaceChild(recordButtonClone, recordButton);
+  stopButton.parentNode.replaceChild(stopButtonClone, stopButton);
 }
 
 export {

--- a/server/static/index.css
+++ b/server/static/index.css
@@ -219,15 +219,38 @@ a {
   cursor: pointer;
 }
 
-.Recorder-recordButton--recording {
-  border: solid 6px darkred;
-  border-radius: 0;
+/* .Recorder-recordButton--recording {
+  border-color: darkred;
   box-shadow: inset 0 0 5px 2px darkred;
-}
-.Recorder-recordButton--disabled {
-  opacity: 0.5;
   cursor: auto;
-  background-color: red;
+  opacity: 0.5;
+} */
+.Recorder-recordButton--recording, .Recorder-recordButton--disabled {
+  opacity: 0.2;
+  cursor: auto;
+}
+.Recorder-stopButton {
+  box-sizing: border-box;
+  background-color: black;
+  border: solid 4px lightgray;
+  border-radius: 0;
+  padding: 5px;
+  font-size: 0px;
+  height: 50px;
+  width: 50px;
+  margin-top: 20px;
+  margin-bottom: 20px;
+  cursor: pointer;
+}
+/* .Recorder-stopButton--stopped {
+  border-color: black;
+  box-shadow: inset 0 0 5px 2px black;
+  cursor: auto;
+  opacity: 0.5;
+} */
+.Recorder-stopButton--stopped, .Recorder-stopButton--disabled {
+  opacity: 0.2;
+  cursor: auto;
 }
 
 .Recorder-time {

--- a/server/static/index.css
+++ b/server/static/index.css
@@ -219,12 +219,6 @@ a {
   cursor: pointer;
 }
 
-/* .Recorder-recordButton--recording {
-  border-color: darkred;
-  box-shadow: inset 0 0 5px 2px darkred;
-  cursor: auto;
-  opacity: 0.5;
-} */
 .Recorder-recordButton--recording, .Recorder-recordButton--disabled {
   opacity: 0.2;
   cursor: auto;
@@ -242,12 +236,6 @@ a {
   margin-bottom: 20px;
   cursor: pointer;
 }
-/* .Recorder-stopButton--stopped {
-  border-color: black;
-  box-shadow: inset 0 0 5px 2px black;
-  cursor: auto;
-  opacity: 0.5;
-} */
 .Recorder-stopButton--stopped, .Recorder-stopButton--disabled {
   opacity: 0.2;
   cursor: auto;

--- a/server/static/index.js
+++ b/server/static/index.js
@@ -305,6 +305,8 @@ const doStartRecording = function() {
     },
   });
 
+  updateRecorderStatus(RECORDER_STATUS_VALUES.STARTING);
+  
   /* UI dispatch */
   // TODO: move into UI component?
   updatePlaybackPlayer({
@@ -322,6 +324,7 @@ const doStartRecording = function() {
 }
 
 const doStopRecording = () => {
+  console.log('doStartRecording() from main');
   state.recorder.callbacks.stopRecording(); // TODO: get a reference to this function, which is returned by initializeRecorder(), below the call to this function
 
   // force re-render
@@ -366,7 +369,6 @@ const handleRequestMediaPermissionsSuccess = function(stream) {
 
   let initialized = {};
 
-  updateRecorderStatus(RECORDER_STATUS_VALUES.STARTING);
   if (!state.recorder.isFlac) {
     initialized = initializeRecorder({
       stream,

--- a/server/static/index.js
+++ b/server/static/index.js
@@ -1,3 +1,4 @@
+// TODO: a bad merge means there is a lot of duplicate/dead code, mostly shared between this file and main.js; identify the dead code and remove it
 import {
   generateUUID,
   merge,
@@ -46,7 +47,7 @@ function renderRecorderAndArrows() {
 }
 
 function renderApp() {
-  console.log('rendering from index!')
+  // console.log('rendering from index!')
   updateApp({ isFlac: state.recorder.isFlac, onFlacClick: onFlacClick });
   renderNoiseList(
     state.noiseList,
@@ -324,7 +325,7 @@ const doStartRecording = function() {
 }
 
 const doStopRecording = () => {
-  console.log('doStartRecording() from main');
+  // console.log('doStartRecording() from main');
   state.recorder.callbacks.stopRecording(); // TODO: get a reference to this function, which is returned by initializeRecorder(), below the call to this function
 
   // force re-render
@@ -334,7 +335,7 @@ const doStopRecording = () => {
 // TODO: consider making this a function generator where we pass in startRecording() and stopRecording()
 // TODO: refactor this big time
 const onRecordClick = function() {
-  console.log('onRecordClick() from index');
+  // console.log('onRecordClick() from index');
   if (state.recorder.status === RECORDER_STATUS_VALUES.WAIT_FOR_CLICK || state.recorder.status === RECORDER_STATUS_VALUES.UPLOADED || state.recorder.status === RECORDER_STATUS_VALUES.ALREADY_RECORDED) {
     if (!state.recorder.explicitlyPermitted) {
       // TODO: consider doing this reacting to state change instead
@@ -412,7 +413,7 @@ const handleRequestMediaPermissionsSuccess = function(stream) {
 
   function onRecordStart() {
     // TODO: start/stop a timer
-    console.log(`Recording started...`);
+    // console.log(`Recording started...`);
     state.recorder.startTime = Date.now();
     if (state.recorder.timer) {
       clearInterval(state.recorder.timer);
@@ -441,8 +442,8 @@ const handleRequestMediaPermissionsSuccess = function(stream) {
 
   // TODO: merge the two functions below
   function onRecordStop() {
-    console.log(`onRecordStop() from index`);
-    console.log(`Recording stopped...`);
+    // console.log(`onRecordStop() from index`);
+    // console.log(`Recording stopped...`);
     if (state.recorder.timer) {
       clearInterval(state.recorder.timer);
     }
@@ -508,13 +509,13 @@ const handleRequestMediaPermissionsSuccess = function(stream) {
     }
     state.recorder.startTime = null;
 
-    console.log(`Recording stopped...`);
-    console.log(`onRecordStopFlac() from index`);
+    // console.log(`Recording stopped...`);
+    // console.log(`onRecordStopFlac() from index`);
   }
 
   function onFileReadyFlac(blob) {
-    console.log(`onFileReadyFlac() from index`);
-    console.log(`File ready to upload...`);
+    // console.log(`onFileReadyFlac() from index`);
+    // console.log(`File ready to upload...`);
 
     // TODO: add state for encoding?
     updateRecorderStatus(RECORDER_STATUS_VALUES.UPLOADING);

--- a/server/static/main.js
+++ b/server/static/main.js
@@ -1,4 +1,5 @@
 // TODO: we are relying on the native import(), which may not be available in our supported browsers; assess and replace with transpilation if necessary
+// TODO: a bad merge means there is a lot of duplicate/dead code, mostly shared between this file and index.js; identify the dead code and remove it
 import { generateUUID } from './utilities.js';
 import {
   renderRecorder,
@@ -88,7 +89,7 @@ function decrementSelectedNoise() {
 
 let adapter = {}; // this object is used as a mea != ns to communicate with the recording code; TODO: replace with more intuitive code
 const firstRecordClick = function() {
-  console.log(state.recorder.status);
+  // console.log(state.recorder.status);
   // TODO: fix this when we separate out recorder status from noise status
   // if (state.recorder.status === NEED_PERMISSIONS) {
   // getUserMedia(); // normal .webm code path
@@ -150,8 +151,8 @@ const handleGetUserMediaSuccess = function(stream) {
   recordButton.parentNode.replaceChild(recordButtonClone, recordButton);
 
   function recordClickHandler() {
-    console.log('recordClickHandler()');
-    console.log(state.recorder);
+    // console.log('recordClickHandler()');
+    // console.log(state.recorder);
     if (state.recorder.status === WAITING) {
       /* state management */
       // state.recorder.recordedChunks = [];
@@ -183,7 +184,7 @@ const handleGetUserMediaSuccess = function(stream) {
   mediaRecorder.addEventListener('dataavailable', function(e) {
     if (e.data.size > 0) {
       // add this chunk of data to the recorded chunks
-      console.log(`Pushing chunk #${++state.recorder.chunkNumber}`);
+      // console.log(`Pushing chunk #${++state.recorder.chunkNumber}`);
 
       /* state management */
       recordedChunks.push(e.data);
@@ -219,7 +220,7 @@ const handleGetUserMediaSuccess = function(stream) {
   });
 
   mediaRecorder.addEventListener('stop', function() {
-    console.log(`stop event from main`);
+    // console.log(`stop event from main`);
 
     /* state management */
     state.recorder.elapsed = Date.now() - state.recorder.startTime;
@@ -307,7 +308,7 @@ function render() {
 }
 
 function renderApp() {
-  console.log('rendering from main!')
+  // console.log('renderApp(): rendering from main!');
   renderNoiseList(
     state.noiseList,
     selectNoise,

--- a/server/templates/index.html
+++ b/server/templates/index.html
@@ -51,6 +51,7 @@
           <div class="Centered-column--fill">
             <div class="Recorder-actions">
               <button data-id="recordButton" class="Recorder-recordButton">Record</button>
+              <button data-id="stopButton" class="Recorder-stopButton">Stop</button>
               <p data-id="recorderTime" class="Recorder-time">00:00</p>
               <p data-id="recorderStatus" class="Recorder-status">Waiting to record</p>
             </div>


### PR DESCRIPTION
This PR splits combination record/stop button into two buttons, one for record and one for stopping recording. The use case is: a user that uses `pop` as a noise trying to record `pop` will have difficulty if their cursor remains over the one combo button, accidentally depressing it while recording.